### PR TITLE
Improve UX of text anchor links by scrolling in advance of the target

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -104,3 +104,11 @@ main .theme-doc-markdown a {
   color: white;
   padding: 20px 0;
 }
+
+/* This makes the page scroll to a position above the anchor specified in url's hash value - to account for the fixed-width header that overlaps the page contents */
+:target::before {
+  content: '';
+  display: block;
+  height:      180px;
+  margin-top: -180px;
+}


### PR DESCRIPTION
By default the text referenced in a hash link (e.g. http://localhost:3000/sql/string#ascii) is being scrolled to so it is on the very top of the page, which hides it behind the header. This commit adds an offset to the scroll position to reach the target anchor